### PR TITLE
fix: private message col command

### DIFF
--- a/src/main/java/com/templeosrs/util/collections/chatcommands/CollectionLogChatCommandChatMessageSubscriber.java
+++ b/src/main/java/com/templeosrs/util/collections/chatcommands/CollectionLogChatCommandChatMessageSubscriber.java
@@ -48,6 +48,7 @@ public class CollectionLogChatCommandChatMessageSubscriber
 		ChatMessageType.PUBLICCHAT,
 		ChatMessageType.FRIENDSCHAT,
 		ChatMessageType.PRIVATECHAT,
+		ChatMessageType.PRIVATECHATOUT,
 		ChatMessageType.CLAN_CHAT,
 		ChatMessageType.CLAN_GIM_MESSAGE,
 		ChatMessageType.CLAN_GIM_CHAT,

--- a/src/main/java/com/templeosrs/util/collections/chatcommands/commands/DisplayPlayerCollectionLogChatCommand.java
+++ b/src/main/java/com/templeosrs/util/collections/chatcommands/commands/DisplayPlayerCollectionLogChatCommand.java
@@ -58,21 +58,25 @@ public class DisplayPlayerCollectionLogChatCommand extends ChatCommand  {
 	{
         final String rawMessage = event.getMessage().trim();
 
-        String[] parts = rawMessage.substring(5).trim().split(" ", 2);
+        final String[] parts = rawMessage.substring(5).trim().split(" ", 2);
 
         if (parts.length == 0) {
             return;
         }
 
         // Normalize boss name
-        String bossInput = parts[0].trim().replace(' ', '_').toLowerCase();
-        CollectionLogCategory category = getCategoryFromMessageInput(bossInput);
+        final String bossInput = parts[0].trim().replace(' ', '_').toLowerCase();
+        final CollectionLogCategory category = getCategoryFromMessageInput(bossInput);
+		final String senderName = event.getType() == ChatMessageType.PRIVATECHATOUT
+			? client.getLocalPlayer().getName()
+			: event.getName();
 
         // Determine target player (specified or sender)
-        String playerName = (parts.length == 2) ? parts[1].trim() : event.getName();
-        String normalizedPlayerName = PlayerNameUtils.normalizePlayerName(playerName);  // Normalize the player name for the API call
-        String localName = PlayerNameUtils.normalizePlayerName(client.getLocalPlayer().getName());
-        boolean isLocalPlayer = normalizedPlayerName.equalsIgnoreCase(localName);
+        final String playerName = (parts.length == 2) ? parts[1].trim() : senderName;
+
+        final String normalizedPlayerName = PlayerNameUtils.normalizePlayerName(playerName);  // Normalize the player name for the API call
+        final String localName = PlayerNameUtils.normalizePlayerName(client.getLocalPlayer().getName());
+        final boolean isLocalPlayer = normalizedPlayerName.equalsIgnoreCase(localName);
 
         if (category == null) {
             if (isLocalPlayer) {
@@ -110,14 +114,14 @@ public class DisplayPlayerCollectionLogChatCommand extends ChatCommand  {
 
         scheduledExecutorService.execute(() ->
         {
-            PlayerInfoResponse.Data playerInfo = getPlayerInfo(normalizedPlayerName, event);
+            final PlayerInfoResponse.Data playerInfo = getPlayerInfo(normalizedPlayerName, event);
 
             if (playerInfo == null) {
                 // Error messages are handled when getting the player info
                 return;
             }
 
-            String prettyPlayerName = playerInfo.getPlayerNameWithCapitalization();
+            final String prettyPlayerName = playerInfo.getPlayerNameWithCapitalization();
 
             if (playerInfo.getCollectionLog().getLastChanged() == null) {
                 overwriteMessage(
@@ -134,7 +138,7 @@ public class DisplayPlayerCollectionLogChatCommand extends ChatCommand  {
                 return;
             }
 
-            String lastChanged = playerInfo.getCollectionLog().getLastChanged();
+            final String lastChanged = playerInfo.getCollectionLog().getLastChanged();
 
             final boolean isDataStale = !collectionLogService.isDataFresh(normalizedPlayerName, lastChanged);
             final boolean hasLocalData = CollectionDatabase.hasPlayerData(normalizedPlayerName);
@@ -143,7 +147,7 @@ public class DisplayPlayerCollectionLogChatCommand extends ChatCommand  {
             if (shouldUpdate)
             {
                 log.debug("📭 No local data for '{}', fetching from API...", normalizedPlayerName);
-                String json = collectionLogRequestManager.getPlayerCollectionLog(normalizedPlayerName);
+                final String json = collectionLogRequestManager.getPlayerCollectionLog(normalizedPlayerName);
 
                 if (json == null) {
                     log.warn("❌ No data fetched for user: {}", normalizedPlayerName);
@@ -175,7 +179,7 @@ public class DisplayPlayerCollectionLogChatCommand extends ChatCommand  {
             }
 
             // Fetch the requested category
-            Set<ObtainedCollectionItem> items = CollectionDatabase.getItemsByCategory(
+            final Set<ObtainedCollectionItem> items = CollectionDatabase.getItemsByCategory(
                     normalizedPlayerName,
 					new LinkedHashSet<>(category.getItems())
             );
@@ -187,12 +191,13 @@ public class DisplayPlayerCollectionLogChatCommand extends ChatCommand  {
 					.collect(Collectors.toList())
 			);
 
-            ChatMessageBuilder chatMessageBuilder = new ChatMessageBuilder();
-            String categoryName = category.getTitle();
+            final ChatMessageBuilder chatMessageBuilder = new ChatMessageBuilder();
+            final String categoryName = category.getTitle();
 
+			assert senderName != null;
 
 			// If sender's name is same as the player being queried, omit the player's name
-			if (!event.getName().equalsIgnoreCase(playerName))
+			if (!senderName.equalsIgnoreCase(playerName))
 			{
 				chatMessageBuilder
 					.append(ChatColorType.HIGHLIGHT)
@@ -216,7 +221,7 @@ public class DisplayPlayerCollectionLogChatCommand extends ChatCommand  {
 
                 for (ObtainedCollectionItem item : items)
                 {
-                    Integer iconIndex = itemSpriteManager.getItemSpriteIndexes().get(item.getId());
+                    final Integer iconIndex = itemSpriteManager.getItemSpriteIndexes().get(item.getId());
 
                     if (iconIndex != null) {
                         chatMessageBuilder.img(iconIndex);
@@ -281,19 +286,19 @@ public class DisplayPlayerCollectionLogChatCommand extends ChatCommand  {
 
     private CollectionLogCategory getCategoryFromMessageInput(String bossInput)
     {
-        String categoryKey = getCategoryKeyFromMessageInput(bossInput);
-        CollectionLogCategory customCategory = CollectionLogCategoryUtils.CUSTOM_CATEGORIES.get(bossInput);
+        final String categoryKey = getCategoryKeyFromMessageInput(bossInput);
+        final CollectionLogCategory customCategory = CollectionLogCategoryUtils.CUSTOM_CATEGORIES.get(bossInput);
 
         if (customCategory != null) {
             return customCategory;
         }
 
         try {
-            int structId = CollectionLogManager.getCollectionLogCategoryStructIdMap().get(categoryKey);
+            final int structId = CollectionLogManager.getCollectionLogCategoryStructIdMap().get(categoryKey);
 
-            StructComposition categoryStruct = client.getStructComposition(structId);
-            String categoryTitle = categoryStruct.getStringValue(689);
-            Set<Integer> categoryItems = CollectionLogManager.getCollectionLogCategoryItemMap().get(categoryStruct.getId());
+            final StructComposition categoryStruct = client.getStructComposition(structId);
+            final String categoryTitle = categoryStruct.getStringValue(689);
+            final Set<Integer> categoryItems = CollectionLogManager.getCollectionLogCategoryItemMap().get(categoryStruct.getId());
 
 			return new CollectionLogCategory(categoryTitle, categoryItems);
 		}

--- a/src/main/java/com/templeosrs/util/collections/chatcommands/commands/DisplayPlayerCollectionLogChatCommand.java
+++ b/src/main/java/com/templeosrs/util/collections/chatcommands/commands/DisplayPlayerCollectionLogChatCommand.java
@@ -67,6 +67,9 @@ public class DisplayPlayerCollectionLogChatCommand extends ChatCommand  {
         // Normalize boss name
         final String bossInput = parts[0].trim().replace(' ', '_').toLowerCase();
         final CollectionLogCategory category = getCategoryFromMessageInput(bossInput);
+
+		// For outgoing PMs, the message should show the current player's log,
+		// but the event contains the recipient's name.
 		final String senderName = event.getType() == ChatMessageType.PRIVATECHATOUT
 			? client.getLocalPlayer().getName()
 			: event.getName();


### PR DESCRIPTION
- Fixes an issue where outgoing private messages weren't parsing the `!col` command
- Fixes an issue where private messages weren't rendering the icon tooltips

<img width="775" height="166" alt="image" src="https://github.com/user-attachments/assets/f993c183-7b9d-4d23-bee6-4ca9e176c244" />
